### PR TITLE
Update README file's instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,8 +79,8 @@ Afterwards, you can test that `kubectl` works by running a command like `kubectl
 1. `kubectl apply -f deployment/db-configmap.yaml` - Set up environment variables for the pods
 2. `kubectl apply -f deployment/db-secret.yaml` - Set up secrets for the pods
 3. `kubectl apply -f deployment/postgres.yaml` - Set up a Postgres database running PostGIS
-4. `kubectl apply -f deployment/udaconnect-api` - Set up the service and deployment for the API
-5. `kubectl apply -f deployment/udaconnect-app` - Set up the service and deployment for the web app
+4. `kubectl apply -f deployment/udaconnect-api.yaml` - Set up the service and deployment for the API
+5. `kubectl apply -f deployment/udaconnect-app.yaml` - Set up the service and deployment for the web app
 6. `sh scripts/run_db_command.sh <POD_NAME>` - Seed your database against the `postgres` pod. (`kubectl get pods` will give you the `POD_NAME`)
 
 Manually applying each of the individual `yaml` files is cumbersome but going through each step provides some context on the content of the starter project. In practice, we would have reduced the number of steps by running the command against a directory to apply of the contents: `kubectl apply -f deployment/`.


### PR DESCRIPTION
All files in the `deployment/` folder have the `.yaml` extension. So, running the commands without this extension will return an error. For example, running ` kubectl apply -f deployment/udaconnect-api ` will fail with  `error: the path "deployment/udaconnect-api" does not exist`