### PR TITLE
Fix connection only show 1 person

### DIFF
--- a/modules/frontend/src/components/Connection.js
+++ b/modules/frontend/src/components/Connection.js
@@ -40,7 +40,7 @@ class Connection extends Component {
         <div className="connectionHeader">Connections</div>
         <ul className="connectionList">
           {this.state.connections.filter((value, index, a) => a.findIndex(v => (
-              v.first_name === value.first_name && v.last_name === value.last_name
+              v.person.id === value.person.id
           )) === index).map((connection, index) => (
             <li className="connectionListItem" key={index}>
               <div className="contact">


### PR DESCRIPTION
The current connections in the front end are only displaying one connection per person. This is because the logic to get the unique person uses incorrect paths, it needs additional `.person` first before able to gain `.first_name` and `.last_name` data.