### PR TITLE
Switch to generic/opensuse15 to support letsencrypt

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,6 +1,6 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
-default_box = "generic/opensuse42"
+default_box = "generic/opensuse15"
 
 # All Vagrant configuration is done below. The "2" in Vagrant.configure
 # configures the configuration version (we support older styles for


### PR DESCRIPTION
Fixes https://github.com/udacity/nd064-c2-message-passing-projects-starter/issues/10

Use "generic" instead of "roboxes", as the former seems more endorsed https://github.com/lavabit/robox/issues/31