### PR TITLE
fix(README): point Docker image to correct reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ We will be installing the tools that we'll need to use for getting our environme
 To run the application, you will need a K8s cluster running locally and to interface with it via `kubectl`. We will be using Vagrant with VirtualBox to run K3s.
 
 #### Initialize K3s
-In this project's root, run `vagrant up`. 
+In this project's root, run `vagrant up`.
 ```bash
 $ vagrant up
 ```
@@ -113,7 +113,7 @@ As a reminder, each module should have:
 4. `__init__.py`
 
 ### Docker Images
-`udaconnect-app` and `udaconnect-api` use docker images from `isjustintime/udaconnect-app` and `isjustintime/udaconnect-api`. To make changes to the application, build your own Docker image and push it to your own DockerHub repository. Replace the existing container registry path with your own.
+`udaconnect-app` and `udaconnect-api` use docker images from `udacity/nd064-udaconnect-app` and `udacity/nd064-udaconnect-api`. To make changes to the application, build your own Docker image and push it to your own DockerHub repository. Replace the existing container registry path with your own.
 
 ## Configs and Secrets
 In `deployment/db-secret.yaml`, the secret variable is `d293aW1zb3NlY3VyZQ==`. The value is simply encoded and not encrypted -- this is ***not*** secure! Anyone can decode it to see what it is.


### PR DESCRIPTION
In the [instructions video](https://youtu.be/uPXY4xY6DEs?t=170), the instructor demonstrates the container image inside the k8s deployment spec pointing to his personal DockerHub, but the current k8s deployment spec points to the Udacity organization. I updated the README to reflect this change.